### PR TITLE
update joshdholtz/github-action-issue-ack dependency

### DIFF
--- a/.github/workflows/issue-notifications.yml
+++ b/.github/workflows/issue-notifications.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Issue Notification Action
-        uses: joshdholtz/github-action-issue-ack@v16
+        uses: joshdholtz/github-action-issue-ack@v17
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
Update joshdholtz/github-action-issue-ack to v17 which:
* Does not trigger notification for pull requests
* Fixes issue where real time notification doesn't look for `acknowledge` label
