### PR TITLE
Add `workflow_call` to shared workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,15 +1,10 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
-
+  workflow_call:
+    secrets:
+      ANTHROPIC_API_KEY:
+        required: true
 jobs:
   claude-review:
     # Only allow org members and owners to trigger Claude reviews

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,14 +1,10 @@
 name: Claude Code
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+  workflow_call:
+    secrets:
+      ANTHROPIC_API_KEY:
+        required: true
 
 jobs:
   claude:


### PR DESCRIPTION
I missed `workflow_call` so these can be reused, otherwise they fail see https://github.com/RevenueCat/purchases-android/actions/runs/21138049487