### PR TITLE
Add model input and spec-checking to Claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -61,6 +61,6 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           claude_args: >-
             ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}
-            --append-system-prompt "CRITICAL: Before reviewing, check if the PR description contains any links to https://github.com/RevenueCat/sdk-specs. If found: 1) Use gh api to fetch all files in the linked spec directory (design.md, spec.md, tasks.md), 2) Read and understand the spec requirements, 3) Verify the implementation matches the spec, 4) Call out any missing requirements or deviations from the spec, 5) Check if the Android equivalent PR (if linked) follows similar patterns."
+            --append-system-prompt "Be critical - look for what's WRONG. 1) If the PR links to https://github.com/RevenueCat/sdk-specs, fetch the spec files via gh api and verify the implementation matches. 2) What edge cases are missing? 3) What tests should exist but don't? 4) What could break in production?"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,8 +11,8 @@ on:
     secrets:
       ANTHROPIC_API_KEY:
         required: true
-      GITHUB_TOKEN_SPECS:
-        description: 'GitHub token with access to RevenueCat/sdk-specs (optional, for spec-checking)'
+      READ_ORG_GITHUB_TOKEN:
+        description: 'GitHub token with read access to RevenueCat org repos (for spec-checking)'
         required: false
 jobs:
   claude-review:
@@ -55,7 +55,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN_SPECS || github.token }}
+          github_token: ${{ secrets.READ_ORG_GITHUB_TOKEN || github.token }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,6 +2,12 @@ name: Claude Code Review
 
 on:
   workflow_call:
+    inputs:
+      model:
+        description: 'Claude model to use (e.g., claude-sonnet-4-20250514, claude-opus-4-5-20251101)'
+        required: false
+        type: string
+        default: ''
     secrets:
       ANTHROPIC_API_KEY:
         required: true
@@ -48,6 +54,16 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            CRITICAL: Before reviewing, check if the PR description contains any links to
+            https://github.com/RevenueCat/sdk-specs. If found:
+            1. Use `gh api` to fetch all files in the linked spec directory (design.md, spec.md, tasks.md)
+            2. Read and understand the spec requirements
+            3. Verify the implementation matches the spec
+            4. Call out any missing requirements or deviations from the spec
+            5. Check if the Android equivalent PR (if linked) follows similar patterns
+          claude_args: ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -61,6 +61,6 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           claude_args: >-
             ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}
-            --append-system-prompt "Be critical - look for what's WRONG. 1) If the PR links to https://github.com/RevenueCat/sdk-specs, fetch the spec files via gh api and verify the implementation matches. 2) What edge cases are missing? 3) What tests should exist but don't? 4) What could break in production?"
+            --append-system-prompt "CRITICAL: Before reviewing, check if the PR description contains any links to https://github.com/RevenueCat/sdk-specs. If found: 1) Use gh api to fetch all files in the linked spec directory (design.md, spec.md, tasks.md), 2) Read and understand the spec requirements, 3) Verify the implementation matches the spec, 4) Call out any missing requirements or deviations from the spec"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,7 +59,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: |
+          claude_args: >-
             ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}
             --append-system-prompt "CRITICAL: Before reviewing, check if the PR description contains any links to https://github.com/RevenueCat/sdk-specs. If found: 1) Use gh api to fetch all files in the linked spec directory (design.md, spec.md, tasks.md), 2) Read and understand the spec requirements, 3) Verify the implementation matches the spec, 4) Call out any missing requirements or deviations from the spec, 5) Check if the Android equivalent PR (if linked) follows similar patterns."
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,9 @@ on:
     secrets:
       ANTHROPIC_API_KEY:
         required: true
+      GITHUB_TOKEN_SPECS:
+        description: 'GitHub token with access to RevenueCat/sdk-specs (optional, for spec-checking)'
+        required: false
 jobs:
   claude-review:
     if: |
@@ -52,18 +55,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN_SPECS || github.token }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: |
-            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
-
-            CRITICAL: Before reviewing, check if the PR description contains any links to
-            https://github.com/RevenueCat/sdk-specs. If found:
-            1. Use `gh api` to fetch all files in the linked spec directory (design.md, spec.md, tasks.md)
-            2. Read and understand the spec requirements
-            3. Verify the implementation matches the spec
-            4. Call out any missing requirements or deviations from the spec
-            5. Check if the Android equivalent PR (if linked) follows similar patterns
-          claude_args: ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: |
+            ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}
+            --append-system-prompt "CRITICAL: Before reviewing, check if the PR description contains any links to https://github.com/RevenueCat/sdk-specs. If found: 1) Use gh api to fetch all files in the linked spec directory (design.md, spec.md, tasks.md), 2) Read and understand the spec requirements, 3) Verify the implementation matches the spec, 4) Call out any missing requirements or deviations from the spec, 5) Check if the Android equivalent PR (if linked) follows similar patterns."
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary

Enhances the Claude code review workflow with:

1. **Model selection** - Add optional `model` input to use different Claude models (e.g., Opus)
2. **Spec-checking** - Automatically fetch and verify implementations against linked specs from `sdk-specs`
3. **Private repo access** - Use existing `READ_ORG_GITHUB_TOKEN` secret for accessing private repos like `sdk-specs`

## Usage

### Basic (default model, no spec access)
```yaml
jobs:
  claude-review:
    uses: revenuecat/sdk-github-workflows/.github/workflows/claude-code-review.yml@v6
    secrets:
      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
```

### With Opus and spec-checking
```yaml
jobs:
  claude-review:
    uses: revenuecat/sdk-github-workflows/.github/workflows/claude-code-review.yml@v6
    with:
      model: claude-opus-4-5-20251101
    secrets:
      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
      READ_ORG_GITHUB_TOKEN: ${{ secrets.READ_ORG_GITHUB_TOKEN }}
```

## Test plan
- [ ] Merge and create version tag (v6)
- [ ] Test on a PR without spec link (should work as before)
- [ ] Test on a PR with spec link (e.g., purchases-ios#6285)
- [ ] Verify spec files are fetched and checked during review

🤖 Generated with [Claude Code](https://claude.com/claude-code)