### PR TITLE
security: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1.0.82
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.READ_ORG_GITHUB_TOKEN || github.token }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1.0.82
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/.github/workflows/issue-notifications.yml
+++ b/.github/workflows/issue-notifications.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Issue Notification Action
-        uses: joshdholtz/github-action-issue-ack@v17
+        uses: joshdholtz/github-action-issue-ack@920321bddad3c0f824db4db697eb1fbf0ef3d617 # v17
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
- Pin all `uses:` references in GitHub Actions workflows to full SHA hashes
- Prevents supply chain attacks via tag mutation or typosquatting

## Context
- https://rosesecurity.dev/2026/03/20/typosquatting-trivy.html
- Generated with [`pinact`](https://github.com/suzuki-shunsuke/pinact)

## Test plan
- [ ] Verify CI passes with pinned references
- [ ] Spot-check that pinned SHAs match expected release tags