### PR TITLE
Add reusable rerun-danger workflow

### DIFF
--- a/.github/workflows/rerun-danger.yml
+++ b/.github/workflows/rerun-danger.yml
@@ -31,6 +31,11 @@ jobs:
     # Skip fork PRs — CircleCI typically doesn't build them, so there's no
     # workflow to rerun.
     if: github.event.pull_request.head.repo.full_name == github.repository
+    # If labels are toggled rapidly, cancel any in-flight run for this PR
+    # so only the latest label state triggers a CircleCI rerun.
+    concurrency:
+      group: rerun-danger-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions: {}
 
     steps:

--- a/.github/workflows/rerun-danger.yml
+++ b/.github/workflows/rerun-danger.yml
@@ -1,0 +1,82 @@
+name: Re-run Danger
+
+# Reusable workflow: re-runs a named CircleCI workflow (default `danger`) for
+# the PR branch's most recent pipeline. Useful when Danger fails for a state
+# that can be fixed without a commit (e.g. adding a missing PR label), since
+# CircleCI otherwise won't re-evaluate without a new push.
+#
+# Callers are expected to trigger this on `pull_request: [labeled, unlabeled]`
+# and supply a CircleCI project slug.
+
+on:
+  workflow_call:
+    inputs:
+      project_slug:
+        description: "CircleCI project slug, e.g. gh/RevenueCat/purchases-ios"
+        required: true
+        type: string
+      workflow_name:
+        description: "Name of the CircleCI workflow to rerun"
+        default: danger
+        type: string
+    secrets:
+      CIRCLECI_TOKEN:
+        required: true
+
+permissions: {}
+
+jobs:
+  rerun-danger:
+    runs-on: ubuntu-latest
+    # Skip fork PRs — CircleCI typically doesn't build them, so there's no
+    # workflow to rerun.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions: {}
+
+    steps:
+      - name: Rerun workflow on CircleCI
+        env:
+          CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          PROJECT_SLUG: ${{ inputs.project_slug }}
+          WORKFLOW_NAME: ${{ inputs.workflow_name }}
+        run: |
+          # 1. Most recent pipeline for this branch
+          PIPELINE_ID=$(curl -s --max-time 15 -G \
+            -H "Circle-Token: $CCI_TOKEN" \
+            --data-urlencode "branch=$BRANCH" \
+            "https://circleci.com/api/v2/project/$PROJECT_SLUG/pipeline" \
+            | jq -r '.items[0].id')
+
+          if [[ -z "$PIPELINE_ID" || "$PIPELINE_ID" == "null" ]]; then
+            echo "::error::No CircleCI pipeline found for branch '$BRANCH'"
+            exit 1
+          fi
+          echo "Found pipeline: $PIPELINE_ID"
+
+          # 2. Most recent instance of the target workflow in that pipeline.
+          # Reruns add new entries, so we pick the newest match (first in list).
+          WORKFLOW_ID=$(curl -s --max-time 15 \
+            -H "Circle-Token: $CCI_TOKEN" \
+            "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" \
+            | jq -r --arg name "$WORKFLOW_NAME" 'first(.items[] | select(.name == $name)) | .id')
+
+          if [[ -z "$WORKFLOW_ID" || "$WORKFLOW_ID" == "null" ]]; then
+            echo "::error::No '$WORKFLOW_NAME' workflow found in pipeline $PIPELINE_ID"
+            exit 1
+          fi
+          echo "Found workflow: $WORKFLOW_ID"
+
+          # 3. Rerun from scratch
+          HTTP_STATUS=$(curl -s --max-time 15 -o /dev/null -w "%{http_code}" -X POST \
+            -H "Circle-Token: $CCI_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"from_failed": false}' \
+            "https://circleci.com/api/v2/workflow/$WORKFLOW_ID/rerun")
+
+          if [[ "$HTTP_STATUS" != "202" ]]; then
+            echo "::error::Failed to rerun workflow. CircleCI returned HTTP $HTTP_STATUS"
+            exit 1
+          fi
+
+          echo "Successfully re-ran '$WORKFLOW_NAME' workflow for branch '$BRANCH'"

--- a/.github/workflows/rerun-danger.yml
+++ b/.github/workflows/rerun-danger.yml
@@ -56,16 +56,26 @@ jobs:
 
           # 2. Most recent instance of the target workflow in that pipeline.
           # Reruns add new entries, so we pick the newest match (first in list).
-          WORKFLOW_ID=$(curl -s --max-time 15 \
+          TARGET_WORKFLOW=$(curl -s --max-time 15 \
             -H "Circle-Token: $CCI_TOKEN" \
             "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" \
-            | jq -r --arg name "$WORKFLOW_NAME" 'first(.items[] | select(.name == $name)) | .id')
+            | jq -c --arg name "$WORKFLOW_NAME" 'first(.items[] | select(.name == $name))')
 
-          if [[ -z "$WORKFLOW_ID" || "$WORKFLOW_ID" == "null" ]]; then
+          if [[ -z "$TARGET_WORKFLOW" || "$TARGET_WORKFLOW" == "null" ]]; then
             echo "::error::No '$WORKFLOW_NAME' workflow found in pipeline $PIPELINE_ID"
             exit 1
           fi
-          echo "Found workflow: $WORKFLOW_ID"
+
+          WORKFLOW_ID=$(echo "$TARGET_WORKFLOW" | jq -r '.id')
+          WORKFLOW_STATUS=$(echo "$TARGET_WORKFLOW" | jq -r '.status')
+          echo "Found workflow: $WORKFLOW_ID (status: $WORKFLOW_STATUS)"
+
+          # If the workflow is still running (e.g. a commit was just pushed),
+          # skip the rerun to avoid duplicate concurrent runs.
+          if [[ "$WORKFLOW_STATUS" == "running" ]]; then
+            echo "Workflow is already running — skipping rerun."
+            exit 0
+          fi
 
           # 3. Rerun from scratch
           HTTP_STATUS=$(curl -s --max-time 15 -o /dev/null -w "%{http_code}" -X POST \


### PR DESCRIPTION
### Problem

When Danger fails on CircleCI for a state that can be fixed without a new commit (e.g. adding a missing PR label), CircleCI won't re-evaluate until someone pushes. The SDK repos that use Danger via CircleCI all need the same fix.

### Solution

Add a reusable workflow that re-runs a named CircleCI workflow (default \`danger\`) for the PR branch's most recent pipeline. Callers trigger on \`pull_request: [labeled, unlabeled]\` and pass their project slug + token.

### Consumer

- [RevenueCat/purchases-ios#6660](https://github.com/RevenueCat/purchases-ios/pull/6660) — first consumer, end-to-end tested there (label add/remove successfully re-runs Danger on CircleCI).

### Design notes

- **Reusable workflow (\`on: workflow_call\`)** — parameterized by \`project_slug\` and \`workflow_name\` (default \`danger\`).
- **Fork filter** — \`github.event.pull_request.head.repo.full_name == github.repository\`. CircleCI typically doesn't build fork PRs, so there's nothing to rerun.
- **Deny-all permissions** — only calls CircleCI's API, no GitHub token scope needed.
- **Env-var interpolation** for all user-controllable values.
- **Curl timeouts** on every call.
- **Most-recent-match** for the workflow lookup — reruns add a new entry to the pipeline's workflow list, so \`first()\` picks the newest one.

### Test plan

- [x] Verified end-to-end via purchases-ios#6660 — labeling the PR triggers the workflow, CircleCI re-runs \`danger\`, unlabeling does the same.