### PR TITLE
Skip rerun-danger when target workflow doesn't exist yet

### DIFF
--- a/.github/workflows/rerun-danger.yml
+++ b/.github/workflows/rerun-danger.yml
@@ -66,9 +66,12 @@ jobs:
             "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" \
             | jq -c --arg name "$WORKFLOW_NAME" 'first(.items[] | select(.name == $name))')
 
+          # If the target workflow doesn't exist yet, the setup pipeline is
+          # still expanding the dynamic config. The initial run will execute
+          # once expansion completes, so there's nothing to rerun.
           if [[ -z "$TARGET_WORKFLOW" || "$TARGET_WORKFLOW" == "null" ]]; then
-            echo "::error::No '$WORKFLOW_NAME' workflow found in pipeline $PIPELINE_ID"
-            exit 1
+            echo "No '$WORKFLOW_NAME' workflow in pipeline $PIPELINE_ID yet — skipping rerun."
+            exit 0
           fi
 
           WORKFLOW_ID=$(echo "$TARGET_WORKFLOW" | jq -r '.id')

--- a/.github/workflows/rerun-danger.yml
+++ b/.github/workflows/rerun-danger.yml
@@ -66,9 +66,9 @@ jobs:
             "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" \
             | jq -c --arg name "$WORKFLOW_NAME" 'first(.items[] | select(.name == $name))')
 
-          # If the target workflow doesn't exist yet, the setup pipeline is
-          # still expanding the dynamic config. The initial run will execute
-          # once expansion completes, so there's nothing to rerun.
+          # If the target workflow doesn't exist yet, CircleCI hasn't created
+          # the pipeline run for this label change. The initial run will
+          # execute once it does, so there's nothing to rerun.
           if [[ -z "$TARGET_WORKFLOW" || "$TARGET_WORKFLOW" == "null" ]]; then
             echo "No '$WORKFLOW_NAME' workflow in pipeline $PIPELINE_ID yet — skipping rerun."
             exit 0


### PR DESCRIPTION
If a label is added quickly after creating a PR, the rerun-danger action can fire before CircleCI has created the pipeline run, and the action fails because the target workflow doesn't exist yet. In that case there's nothing to rerun anyway — the workflow still has to run for the first time. Skip with `exit 0` instead of failing.

This is especially likely when an AI agent uses the `gh` CLI to create a PR and add a label back-to-back.